### PR TITLE
fix: jinja import error & create_time exception

### DIFF
--- a/rebuild.py
+++ b/rebuild.py
@@ -249,8 +249,11 @@ def get_link_from_row(row: LinkRow) -> Link:
     """
     if row[get_column_index("create_time")] is None:
         raise ValueError(
-            "Line %s has missing create_time value."
-            % row
+            "Line %s - Title: %s - has missing create_time value."
+            % (
+                row[get_column_index("line_number")] + 1,
+                row[get_column_index("title")],
+            )
         )
     link = Link(
         row[get_column_index("line_number")],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.11.1
+Jinja2==3.1.2
 python-slugify==4.0.1
 openpyxl==3.0.7
 


### PR DESCRIPTION
- The current Jinja version is unsupported [(issue link)](https://github.com/pallets/jinja/issues/1585) and raises errors on the project build. The requirements file is updated
- `rebuild.py` L251 `ValueError` string formatting was not working. It's fixed, and the title was added to the error message
- Spreadsheet L253 has no title and create time. The project is not able to have built

